### PR TITLE
feat: improve provider config discovery and add custom credentials doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@
 
 Contributions are welcome! Please read our [Contributing Guidelines](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md).
 
+For testers and developers, check the [Custom OAuth Provider Setup](docs/EXTERNAL_PROVIDERS.md) guide to use your own credentials.
+
 ## Related Projects
 
 - [GNOME Online Accounts](https://gitlab.gnome.org/GNOME/gnome-online-accounts) - Inspiration for this project

--- a/accounts-daemon/src/auth.rs
+++ b/accounts-daemon/src/auth.rs
@@ -30,15 +30,12 @@ impl AuthManager {
         let mut configs = HashMap::new();
 
         for provider in Provider::list() {
-            let config_path =
-                Path::new("accounts-daemon/data/providers").join(provider.file_name());
-            if !config_path.exists() {
-                tracing::error!("Provider config file not found: {}", config_path.display());
-                continue;
+            if let Some(mut config) = Self::load_provider_config(&provider)? {
+                Self::apply_env_overrides(&provider, &mut config);
+                configs.insert(provider, config);
+            } else {
+                tracing::error!("Provider config for {:?} not found in any location", provider);
             }
-            let content = std::fs::read_to_string(config_path)?;
-            let toml_config: AccountProviderConfig = toml::from_str(&content)?;
-            configs.insert(provider.clone(), toml_config.provider);
         }
 
         Ok(Self {
@@ -47,6 +44,58 @@ impl AuthManager {
             storage: CredentialStorage::new().await?,
             config: AccountsConfig::config(),
         })
+    }
+
+    fn load_provider_config(provider: &Provider) -> Result<Option<ProviderConfig>> {
+        let file_name = provider.file_name();
+        let paths = vec![
+            // 1. User config: ~/.config/cosmic/accounts/providers/
+            std::env::var("XDG_CONFIG_HOME")
+                .map(|p| Path::new(&p).to_path_buf())
+                .unwrap_or_else(|_| {
+                    let home = std::env::var("HOME").unwrap_or_default();
+                    Path::new(&home).join(".config")
+                })
+                .join("cosmic/accounts/providers")
+                .join(file_name),
+            // 2. System config: /etc/cosmic/accounts/providers/
+            Path::new("/etc/cosmic/accounts/providers").join(file_name),
+            // 3. System data: /usr/share/cosmic/accounts/providers/
+            Path::new("/usr/share/cosmic/accounts/providers").join(file_name),
+            // 4. Built-in/Dev path
+            Path::new("accounts-daemon/data/providers").join(file_name),
+        ];
+
+        for path in paths {
+            if path.exists() {
+                tracing::info!("Loading {:?} config from: {}", provider, path.display());
+                let content = std::fs::read_to_string(path)?;
+                let toml_config: AccountProviderConfig = toml::from_str(&content)?;
+                return Ok(Some(toml_config.provider));
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn apply_env_overrides(provider: &Provider, config: &mut ProviderConfig) {
+        let provider_env = match provider {
+            Provider::Google => "GOOGLE",
+            Provider::Microsoft => "MICROSOFT",
+        };
+
+        let client_id_env = format!("COSMIC_ACCOUNTS_{}_CLIENT_ID", provider_env);
+        let client_secret_env = format!("COSMIC_ACCOUNTS_{}_CLIENT_SECRET", provider_env);
+
+        if let Ok(val) = std::env::var(&client_id_env) {
+            tracing::info!("Overriding {:?} client_id from env: {}", provider, client_id_env);
+            config.client_id = val;
+        }
+
+        if let Ok(val) = std::env::var(&client_secret_env) {
+            tracing::info!("Overriding {:?} client_secret from env: {}", provider, client_secret_env);
+            config.client_secret = val;
+        }
     }
 
     pub async fn start_auth_flow(&mut self, provider: Provider) -> Result<String> {

--- a/docs/EXTERNAL_PROVIDERS.md
+++ b/docs/EXTERNAL_PROVIDERS.md
@@ -1,0 +1,74 @@
+# Custom OAuth Provider Setup
+
+Because the official COSMIC Online Accounts apps are currently in the testing phase, only pre-approved developer accounts can log in using the default credentials.
+
+If you are a tester or a user who wants to use the app today, you can easily provide your own OAuth credentials.
+
+## 1. Create your own OAuth Application
+
+### Google
+1. Go to the [Google Cloud Console](https://console.cloud.google.com/).
+2. Create a new project.
+3. Search for "APIs & Services" > "Credentials".
+4. Click "Create Credentials" > "OAuth client ID".
+5. Choose "Web application" (even though this is a desktop app, we use a local callback).
+6. Add Authorized Redirect URIs: `http://127.0.0.1:8080/callback`.
+7. Note your **Client ID** and **Client Secret**.
+8. Enable the following APIs for your project:
+   - Google Calendar API
+   - People API
+   - Tasks API
+   - Gmail API
+
+### Microsoft
+1. Go to the [Azure Portal](https://portal.azure.com/).
+2. Search for "App registrations" and click "New registration".
+3. Name it "COSMIC Accounts" and select "Accounts in any organizational directory (Any Microsoft Entra ID tenant - Multitenant) and personal Microsoft accounts".
+4. In "Authentication", add a "Web" platform with Redirect URI: `http://127.0.0.1:8080/callback`.
+5. Under "Certificates & secrets", create a new "Client secret".
+6. Note your **Application (client) ID** and the **Secret Value**.
+
+---
+
+## 2. Apply your Credentials
+
+You can apply your credentials in two ways:
+
+### Option A: Configuration Files (Recommended)
+Create a provider TOML file in your user config directory:
+`~/.config/cosmic/accounts/providers/google.toml` (or `microsoft.toml`)
+
+**Example `google.toml`:**
+```toml
+[provider]
+client_id = "your-id.googleusercontent.com"
+client_secret = "your-secret"
+auth_url = "https://accounts.google.com/o/oauth2/v2/auth"
+token_url = "https://www.googleapis.com/oauth2/v3/token"
+redirect_uri = "http://127.0.0.1:8080/callback"
+scopes = [
+    "https://www.googleapis.com/auth/userinfo.email",
+    "https://www.googleapis.com/auth/userinfo.profile",
+    "https://www.googleapis.com/auth/calendar",
+    "https://www.googleapis.com/auth/contacts",
+    "https://www.googleapis.com/auth/tasks"
+]
+```
+
+### Option B: Environment Variables
+For quick testing, you can run the daemon with environment variables:
+
+```bash
+COSMIC_ACCOUNTS_GOOGLE_CLIENT_ID="your-id" 
+COSMIC_ACCOUNTS_GOOGLE_CLIENT_SECRET="your-secret" 
+accounts-daemon
+```
+
+---
+
+## Technical Details for Contributors
+The daemon searches for configurations in this order:
+1. `$XDG_CONFIG_HOME/cosmic/accounts/providers/`
+2. `/etc/cosmic/accounts/providers/`
+3. `/usr/share/cosmic/accounts/providers/`
+4. Local development path (`accounts-daemon/data/providers/`)

--- a/justfile
+++ b/justfile
@@ -55,9 +55,9 @@ install-gui: build-gui
 
 # Install provider configurations (requires sudo)
 install-configs:
-    sudo mkdir -p /etc/accounts/providers
-    sudo cp data/providers/*.toml /etc/accounts/providers/
-    @echo "Remember to update OAuth2 credentials in /etc/accounts/providers/"
+    sudo mkdir -p /etc/cosmic/accounts/providers
+    sudo cp data/providers/*.toml /etc/cosmic/accounts/providers/
+    @echo "Remember to update OAuth2 credentials in /etc/cosmic/accounts/providers/"
 
 # Install everything (requires sudo)
 install: build install-daemon install-gui install-configs
@@ -67,7 +67,7 @@ uninstall:
     sudo rm -f /usr/bin/accounts-daemon
     sudo rm -f /usr/bin/accounts-ui
     sudo rm -f /usr/share/dbus-1/services/accounts.service
-    sudo rm -rf /etc/accounts
+    sudo rm -rf /etc/cosmic/accounts
 
 # Start the daemon service (user session)
 start-daemon:


### PR DESCRIPTION
This PR improves the provider configuration discovery mechanism and adds documentation for setting up custom OAuth credentials.

### Changes:
- **`accounts-daemon/src/auth.rs`**: Implemented a more robust configuration loading order:
  1. User config: `~/.config/cosmic/accounts/providers/`
  2. System config: `/etc/cosmic/accounts/providers/`
  3. System data: `/usr/share/cosmic/accounts/providers/`
  4. Built-in/Dev path: `accounts-daemon/data/providers/`
- **`accounts-daemon/src/auth.rs`**: Added support for overriding `client_id` and `client_secret` via environment variables (`COSMIC_ACCOUNTS_GOOGLE_CLIENT_ID`, etc.).
- **`docs/EXTERNAL_PROVIDERS.md`**: New guide for users and testers on how to create their own OAuth applications and configure them.
- **`justfile`**: Updated `install-configs` and `uninstall` paths to match the new `/etc/cosmic/accounts/providers/` directory for consistency with other COSMIC components.
- **`README.md`**: Added a reference to the new documentation.

Verified that the daemon correctly loads configurations from the new paths and that the services (Email, Calendar) initialize properly.